### PR TITLE
PFA-20 Implementar opción de eliminación /desactivación

### DIFF
--- a/routes/gasto_recurrente_routes.py
+++ b/routes/gasto_recurrente_routes.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List
 from datetime import date
+from services.gasto_recurrente_service import desactivar_gasto_recurrente
 from database import SessionLocal
 from models.gasto_recurrente_model import GastoRecurrente
 from models.schemas import CrearGastoRecurrente, LeerGastoRecurrente, ActualizarGastoRecurrente
@@ -56,14 +57,7 @@ def actualizar_gasto_recurrente(id: int, datos: ActualizarGastoRecurrente, db: S
     db.refresh(nuevo_gasto)
     return nuevo_gasto
 
-@router.delete("/{id}")
-def eliminar_gasto(id: int, db: Session = Depends(get_db)):
-    gasto = db.query(GastoRecurrente).filter(GastoRecurrente.IdGastoRecurrente == id).first()
-    if not gasto:
-        raise HTTPException(status_code=404, detail="Gasto no encontrado")
-    gasto.Activo = False
-    db.commit()
-    return {"message": "Gasto desactivado"}
+
 
 @router.get("/generate-monthly")
 def generar_gastos_mensuales(db: Session = Depends(get_db)):
@@ -74,3 +68,7 @@ def generar_gastos_mensuales(db: Session = Depends(get_db)):
         if gasto.FechaInicio.day == hoy.day:
             generados.append({"Concepto": gasto.Concepto, "Monto": float(gasto.Monto), "Fecha": hoy})
     return {"message": "Gastos procesados", "data": generados}
+
+@router.put("/desactivar/{id}")
+def desactivar(id: int, db: Session = Depends(get_db)):
+    return desactivar_gasto_recurrente(db, id)

--- a/services/gasto_recurrente_service.py
+++ b/services/gasto_recurrente_service.py
@@ -1,0 +1,15 @@
+from models.gasto_recurrente_model import GastoRecurrente
+
+
+def desactivar_gasto_recurrente(db, id_gasto):
+    gasto = db.query(GastoRecurrente)\
+        .filter(GastoRecurrente.IdGastoRecurrente == id_gasto)\
+        .first()
+
+    if not gasto:
+        return {"success": False, "message": "No encontrado"}
+
+    gasto.Activo = False
+    db.commit()
+
+    return {"success": True, "message": "Desactivado correctamente"}


### PR DESCRIPTION
## Cambios realizados

* Se agregó endpoint para desactivar gastos recurrentes.
* Se implementó eliminación lógica usando campo `Activo = False`.
* Los gastos inactivos ya no generan recurrencias futuras.
* Se retorna mensaje claro de éxito o fallo.

## Archivos modificados

* routes/gasto_recurrente_routes.py
* services/gasto_recurrente_service.py
