### PR TITLE
PFA-52 Editar gastos recurrentes (frontend)

### DIFF
--- a/Frontend/editar_gasto_recurrente.html
+++ b/Frontend/editar_gasto_recurrente.html
@@ -1,0 +1,118 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Editar Gasto Recurrente</title>
+    <link rel="stylesheet" href="css/usuario_style.css">
+
+    <style>
+        body {
+            background-color: var(--bg-color);
+            font-family: Arial, sans-serif;
+        }
+
+        .container {
+            max-width: 500px;
+            margin: 50px auto;
+            background: white;
+            padding: 30px;
+            border-radius: 12px;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+        }
+
+        h2 {
+            color: var(--primary);
+            margin-bottom: 20px;
+            text-align: center;
+        }
+
+        form {
+            display: flex;
+            flex-direction: column;
+            gap: 15px;
+        }
+
+        input, select {
+            padding: 10px;
+            border: 1px solid #ddd;
+            border-radius: 6px;
+        }
+
+        .buttons {
+            display: flex;
+            gap: 10px;
+        }
+
+        button {
+            padding: 10px;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+        }
+
+        .btn-guardar {
+            background-color: #2563eb;
+            color: white;
+        }
+
+        .btn-cancelar {
+            background-color: #e5e7eb;
+        }
+
+        .mensaje {
+            margin-top: 15px;
+            color: #16a34a;
+            font-weight: bold;
+            text-align: center;
+        }
+    </style>
+</head>
+
+<body>
+
+<div class="container">
+
+    <h2>✏️ Editar Gasto Recurrente</h2>
+
+    <form id="editForm">
+
+        <input type="hidden" id="expenseId">
+
+        <label>Concepto</label>
+        <input type="text" id="concepto" required>
+
+        <label>Monto</label>
+        <input type="number" id="monto" required>
+
+        <label>Frecuencia</label>
+        <select id="frecuencia">
+            <option value="Semanal">Semanal</option>
+            <option value="Mensual">Mensual</option>
+        </select>
+
+        <div class="buttons">
+
+            <button type="submit" class="btn-guardar">
+                Guardar Cambios
+            </button>
+
+            <button type="button"
+                    class="btn-cancelar"
+                    onclick="cancelar()">
+
+                Cancelar
+
+            </button>
+
+        </div>
+
+    </form>
+
+    <p class="mensaje" id="mensaje"></p>
+
+</div>
+
+<script src="js/editar_gasto_recurrente.js"></script>
+
+</body>
+</html>

--- a/Frontend/js/editar_gasto_recurrente.js
+++ b/Frontend/js/editar_gasto_recurrente.js
@@ -1,0 +1,126 @@
+const API_URL = "http://127.0.0.1:8000";
+
+// Obtener ID desde la URL
+function obtenerId() {
+
+    const params = new URLSearchParams(window.location.search);
+
+    return params.get("id");
+}
+
+// Cargar gasto actual
+async function cargarGasto() {
+
+    const id = obtenerId();
+
+    if (!id) {
+        alert("ID inválido");
+        return;
+    }
+
+    try {
+
+        const response = await fetch(
+            `${API_URL}/gastos-recurrentes/${id}`
+        );
+
+        if (!response.ok) {
+            throw new Error("No se pudo cargar el gasto");
+        }
+
+        const gasto = await response.json();
+
+        console.log("Gasto cargado:", gasto);
+
+        // Llenar formulario
+        document.getElementById("expenseId").value =
+            gasto.IdGastoRecurrente;
+
+        document.getElementById("concepto").value =
+            gasto.Concepto;
+
+        document.getElementById("monto").value =
+            gasto.Monto;
+
+        document.getElementById("frecuencia").value =
+            gasto.Frecuencia;
+
+    } catch (error) {
+
+        console.error("Error:", error);
+
+        alert("Error al cargar gasto");
+    }
+}
+
+// Guardar cambios
+document.getElementById("editForm")
+.addEventListener("submit", async function(e) {
+
+    e.preventDefault();
+
+    const id = document.getElementById("expenseId").value;
+
+    const datosActualizados = {
+
+        Concepto:
+            document.getElementById("concepto").value,
+
+        Monto:
+            parseFloat(
+                document.getElementById("monto").value
+            ),
+
+        Frecuencia:
+            document.getElementById("frecuencia").value
+    };
+
+    try {
+
+        const response = await fetch(
+            `${API_URL}/gastos-recurrentes/${id}`,
+            {
+                method: "PUT",
+
+                headers: {
+                    "Content-Type": "application/json"
+                },
+
+                body: JSON.stringify(datosActualizados)
+            }
+        );
+
+        if (!response.ok) {
+            throw new Error("No se pudo actualizar");
+        }
+
+        alert(
+            "✅ Gasto actualizado correctamente " +
+            "(solo futuras recurrencias)"
+        );
+
+        // Regresar al listado
+        window.location.href =
+            "listar_gastos_recurrentes.html";
+
+    } catch (error) {
+
+        console.error("Error:", error);
+
+        alert("Error al actualizar gasto");
+    }
+
+});
+
+// Cancelar edición
+function cancelar() {
+
+    window.location.href =
+        "listar_gastos_recurrentes.html";
+}
+
+// Inicializar página
+document.addEventListener(
+    "DOMContentLoaded",
+    cargarGasto
+);

--- a/Frontend/js/listar_gastos.js
+++ b/Frontend/js/listar_gastos.js
@@ -30,6 +30,10 @@ async function cargarGastos() {
                 <td>${gasto.FechaInicio}</td>
                 <td>${gasto.Frecuencia}</td>
                 <td>
+                    <button onclick="editarGasto(${gasto.IdGastoRecurrente})">
+                        ✏️Editar
+                    </button>
+
                     <button class="btn-eliminar" onclick="eliminarGasto(${gasto.IdGastoRecurrente})">
                         Eliminar
                     </button>
@@ -44,6 +48,11 @@ async function cargarGastos() {
     }
 }
 
+
+function editarGasto(id) {
+    if (!id) return;
+    window.location.href = `editar_gasto_recurrente.html?id=${id}`;
+}
 // Función para desactivar (eliminar lógico)
 async function eliminarGasto(id) {
     if (!confirm("¿Seguro que deseas desactivar este gasto?")) return;

--- a/models/schemas.py
+++ b/models/schemas.py
@@ -55,9 +55,9 @@ class GastoResponse(GastoBase):
 
     class Config:
         from_attributes = True # Equivalente a orm_mode en Pydantic v2
-
 class FrecuenciaEnum(str, Enum):
-    mensual = "mensual"
+    semanal = "Semanal"
+    mensual = "Mensual"
 
 class CrearGastoRecurrente(BaseModel):
     Concepto: str = Field(..., min_length=1)

--- a/routes/gasto_recurrente_routes.py
+++ b/routes/gasto_recurrente_routes.py
@@ -34,6 +34,22 @@ def crear_gasto_recurrente(gasto: CrearGastoRecurrente, db: Session = Depends(ge
 @router.get("/", response_model=List[LeerGastoRecurrente])
 def listar_gastos_recurrentes(db: Session = Depends(get_db)):
     return db.query(GastoRecurrente).filter(GastoRecurrente.Activo == True).all()
+@router.get("/{id}", response_model=LeerGastoRecurrente)
+def obtener_gasto_recurrente(id: int, db: Session = Depends(get_db)):
+
+    gasto = db.query(GastoRecurrente).filter(
+        GastoRecurrente.IdGastoRecurrente == id,
+        GastoRecurrente.Activo == True
+    ).first()
+
+    if not gasto:
+        raise HTTPException(
+            status_code=404,
+            detail="Gasto no encontrado"
+        )
+
+    return gasto
+
 
 @router.put("/{id}", response_model=LeerGastoRecurrente)
 def actualizar_gasto_recurrente(id: int, datos: ActualizarGastoRecurrente, db: Session = Depends(get_db)):


### PR DESCRIPTION
## Cambios realizados

* Se agregó funcionalidad para editar gastos recurrentes desde la interfaz.
* Se creó la vista `editar_gasto_recurrente.html`.
* Se implementó `editar_gasto_recurrente.js` para cargar y actualizar datos.
* Se agregó botón de edición en el listado de gastos recurrentes.
* Se integró consumo de API para obtener y actualizar gastos recurrentes.
* Los cambios aplican únicamente a futuras recurrencias.
* El historial de gastos anteriores no se modifica.

## Archivos modificados

### Frontend

* `Frontend/listar_gastos_recurrentes.html`
* `Frontend/editar_gasto_recurrente.html`
* `Frontend/js/listar_gastos.js`
* `Frontend/js/editar_gasto_recurrente.js`

### Backend

* `routes/gasto_recurrente_routes.py`
* `models/schemas.py`

## Validaciones realizadas

* Carga correcta de gastos recurrentes.
* Edición funcional desde interfaz.
* Persistencia correcta en base de datos.
* Conservación de historial de gastos previos.
