### PR TITLE
PFA-71 Generar gasto cada mes

### DIFF
--- a/create_db.sql
+++ b/create_db.sql
@@ -65,5 +65,18 @@ CREATE TABLE Movimiento (
 );
 GO
 
+
+CREATE TABLE GastoRecurrente (
+  IdGastoRecurrente INT PRIMARY KEY IDENTITY(1,1),
+  Concepto VARCHAR(100) NOT NULL,
+  Monto DECIMAL(12,2) NOT NULL,
+  FechaInicio DATETIME NOT NULL,
+  Frecuencia VARCHAR(20) NOT NULL,
+  IdCliente INT NOT NULL,
+  CONSTRAINT FK_GastoRecurrente_Cliente FOREIGN KEY (IdCliente) REFERENCES Cliente(IdCliente)
+);
+ALTER TABLE GastoRecurrente
+ADD Activo BIT NOT NULL DEFAULT 1;
+
 PRINT 'Database SistemasGastosAS created successfully!';
 

--- a/main.py
+++ b/main.py
@@ -10,6 +10,8 @@ from routes.gasto_routes import router as gasto_router
 from routes.ingreso_routes import router as ingreso_router
 from routes.filtrado_routes import router as filtrado_router
 from fastapi.middleware.cors import CORSMiddleware
+from models.tipo_movimiento_model import TipoMovimiento
+from models.movimiento_model import Movimiento
 
 
 from routes.movimiento_routes import router as movimiento_router

--- a/models/tipo_movimiento_model.py
+++ b/models/tipo_movimiento_model.py
@@ -1,0 +1,9 @@
+from sqlalchemy import Column, Integer, String
+from database import Base
+
+class TipoMovimiento(Base):
+    __tablename__ = "TipoMovimiento"
+
+    IdTipo = Column(Integer, primary_key=True, index=True)
+    Nombre = Column(String)
+    Naturaleza = Column(String)

--- a/routes/gasto_recurrente_routes.py
+++ b/routes/gasto_recurrente_routes.py
@@ -1,14 +1,24 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List
-from datetime import date
-from services.gasto_recurrente_service import desactivar_gasto_recurrente
+from datetime import date, datetime
+
 from database import SessionLocal
 from models.gasto_recurrente_model import GastoRecurrente
-from models.schemas import CrearGastoRecurrente, LeerGastoRecurrente, ActualizarGastoRecurrente
+from models.movimiento_model import Movimiento
+from models.schemas import (
+    CrearGastoRecurrente,
+    LeerGastoRecurrente,
+    ActualizarGastoRecurrente
+)
+from services.gasto_recurrente_service import desactivar_gasto_recurrente
 
 router = APIRouter()
 
+
+# ------------------------
+# DB Dependency
+# ------------------------
 def get_db():
     db = SessionLocal()
     try:
@@ -16,6 +26,10 @@ def get_db():
     finally:
         db.close()
 
+
+# ------------------------
+# CREATE GASTO RECURRENTE
+# ------------------------
 @router.post("/", response_model=LeerGastoRecurrente)
 def crear_gasto_recurrente(gasto: CrearGastoRecurrente, db: Session = Depends(get_db)):
     nuevo = GastoRecurrente(
@@ -31,17 +45,32 @@ def crear_gasto_recurrente(gasto: CrearGastoRecurrente, db: Session = Depends(ge
     db.refresh(nuevo)
     return nuevo
 
+
+# ------------------------
+# LISTAR GASTOS RECURRENTES
+# ------------------------
 @router.get("/", response_model=List[LeerGastoRecurrente])
 def listar_gastos_recurrentes(db: Session = Depends(get_db)):
-    return db.query(GastoRecurrente).filter(GastoRecurrente.Activo == True).all()
+    return db.query(GastoRecurrente).filter(
+        GastoRecurrente.Activo == True
+    ).all()
 
+
+# ------------------------
+# ACTUALIZAR (REEMPLAZO LÓGICO)
+# ------------------------
 @router.put("/{id}", response_model=LeerGastoRecurrente)
 def actualizar_gasto_recurrente(id: int, datos: ActualizarGastoRecurrente, db: Session = Depends(get_db)):
-    gasto_actual = db.query(GastoRecurrente).filter(GastoRecurrente.IdGastoRecurrente == id, GastoRecurrente.Activo == True).first()
+
+    gasto_actual = db.query(GastoRecurrente).filter(
+        GastoRecurrente.IdGastoRecurrente == id,
+        GastoRecurrente.Activo == True
+    ).first()
+
     if not gasto_actual:
         raise HTTPException(status_code=404, detail="Gasto no encontrado")
 
-    gasto_actual.Activo = False # Desactivado lógico
+    gasto_actual.Activo = False
     db.commit()
 
     nuevo_gasto = GastoRecurrente(
@@ -52,23 +81,67 @@ def actualizar_gasto_recurrente(id: int, datos: ActualizarGastoRecurrente, db: S
         IdCliente=gasto_actual.IdCliente,
         Activo=True
     )
+
     db.add(nuevo_gasto)
     db.commit()
     db.refresh(nuevo_gasto)
+
     return nuevo_gasto
 
 
-
+# ------------------------
+# GENERAR GASTOS MENSUALES (CORRECTO)
+# ------------------------
 @router.get("/generate-monthly")
 def generar_gastos_mensuales(db: Session = Depends(get_db)):
-    hoy = date.today()
-    gastos = db.query(GastoRecurrente).filter(GastoRecurrente.Activo == True).all()
-    generados = []
-    for gasto in gastos:
-        if gasto.FechaInicio.day == hoy.day:
-            generados.append({"Concepto": gasto.Concepto, "Monto": float(gasto.Monto), "Fecha": hoy})
-    return {"message": "Gastos procesados", "data": generados}
 
+    hoy = date.today()
+    inicio_mes = datetime(hoy.year, hoy.month, 1)
+
+    gastos = db.query(GastoRecurrente).filter(
+        GastoRecurrente.Activo == True
+    ).all()
+
+    generados = []
+
+    for gasto in gastos:
+
+        # Evitar duplicados en el mismo mes
+        existe = db.query(Movimiento).filter(
+            Movimiento.Concepto == gasto.Concepto,
+            Movimiento.IdCliente == gasto.IdCliente,
+            Movimiento.FechaMovimiento >= inicio_mes
+        ).first()
+
+        if not existe:
+
+            nuevo = Movimiento(
+                Concepto=gasto.Concepto,
+                Monto=gasto.Monto,
+                FechaMovimiento=datetime.now(),
+                IdCliente=gasto.IdCliente,
+                IdTipo=2  # egreso
+            )
+
+            db.add(nuevo)
+
+            generados.append({
+                "Concepto": gasto.Concepto,
+                "Monto": float(gasto.Monto),
+                "Fecha": hoy
+            })
+
+    db.commit()
+
+    return {
+        "message": "Gastos mensuales generados correctamente",
+        "data": generados
+    }
+
+
+# ------------------------
+# DESACTIVAR GASTO
+# ------------------------
 @router.put("/desactivar/{id}")
 def desactivar(id: int, db: Session = Depends(get_db)):
     return desactivar_gasto_recurrente(db, id)


### PR DESCRIPTION
## Descripción

Se implementó la generación automática de gastos recurrentes mensuales.

### Cambios realizados

* Se agregó el endpoint `/gastos-recurrentes/generate-monthly`
* Se generan movimientos automáticamente a partir de gastos recurrentes activos
* Se evita la duplicación de movimientos generados el mismo día
* Se agregó el modelo `TipoMovimiento`
* Se actualizaron configuraciones de base de datos y rutas necesarias

### Resultado

El sistema ahora registra automáticamente los gastos recurrentes en la tabla `Movimiento`.
