### PR TITLE
feat: agregar pruebas unitarias de presupuestos

### DIFF
--- a/tests/test_presupuestos/test_budget_routes.py
+++ b/tests/test_presupuestos/test_budget_routes.py
@@ -1,0 +1,42 @@
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_create_presupuesto_exitoso():
+    with patch("routes.budget_routes.registrar_presupuesto") as mock_reg:
+        with patch("routes.budget_routes.DataManager") as mock_dm:
+            mock_reg.return_value = {"success": True, "message": "Presupuesto registrado: $500.0"}
+            mock_dm.return_value.get_categories_data.return_value = []
+            response = client.post("/presupuestos/", json={
+                "user_id": 1,
+                "month": "2026-05",
+                "category": "Comida",
+                "amount": 500.0
+            })
+            assert response.status_code == 200
+            assert response.json()["success"] == True
+
+
+def test_create_presupuesto_error_validacion():
+    with patch("routes.budget_routes.registrar_presupuesto") as mock_reg:
+        mock_reg.side_effect = ValueError("Categoria no existe")
+        response = client.post("/presupuestos/", json={
+            "user_id": 1,
+            "month": "2026-05",
+            "category": "Invalida",
+            "amount": 500.0
+        })
+        assert response.status_code == 400
+
+
+def test_get_presupuestos_exitoso():
+    with patch("routes.budget_routes.DataManager") as mock_dm:
+        mock_dm.return_value.get_categories_data.return_value = [
+            {"categoria": "Comida", "monto": 500.0}
+        ]
+        response = client.get("/presupuestos/1/2026-05")
+        assert response.status_code == 200
+        assert "presupuestos" in response.json()

--- a/tests/test_presupuestos/test_budget_service.py
+++ b/tests/test_presupuestos/test_budget_service.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch, MagicMock
+from services.budget_service import registrar_presupuesto
+
+
+def test_registrar_presupuesto_exitoso():
+    with patch("services.budget_service.sp_registrar_presupuesto") as mock_sp:
+        mock_sp.return_value = None
+        with patch.dict("sys.modules", {"sabeerquees.db_manager": MagicMock(sp_registrar_presupuesto=mock_sp)}):
+            result = registrar_presupuesto(1, "2026-05", "Comida", 500.0)
+            assert result["success"] == True
+            assert "500" in result["message"]
+
+
+def test_registrar_presupuesto_categoria_none():
+    with patch("services.budget_service.sp_registrar_presupuesto") as mock_sp:
+        mock_sp.return_value = None
+        with patch.dict("sys.modules", {"sabeerquees.db_manager": MagicMock(sp_registrar_presupuesto=mock_sp)}):
+            result = registrar_presupuesto(1, "2026-05", None, 300.0)
+            assert result["success"] == True
+            assert "General" in result["message"]
+
+
+def test_registrar_presupuesto_monto_en_mensaje():
+    with patch("services.budget_service.sp_registrar_presupuesto") as mock_sp:
+        mock_sp.return_value = None
+        with patch.dict("sys.modules", {"sabeerquees.db_manager": MagicMock(sp_registrar_presupuesto=mock_sp)}):
+            result = registrar_presupuesto(1, "2026-05", "Transporte", 150.0)
+            assert "150" in result["message"]

--- a/tests/test_presupuestos/test_presupuesto_model.py
+++ b/tests/test_presupuestos/test_presupuesto_model.py
@@ -1,0 +1,57 @@
+import pytest
+from pydantic import ValidationError
+from models.presupuesto_model import PresupuestoCreate, PresupuestoUpdate, PresupuestoResponse
+
+
+def test_presupuesto_create_valido():
+    p = PresupuestoCreate(
+        monto_presupuesto=500.0,
+        id_categoria=1,
+        mes_aplicacion="2026-05",
+        id_usuario=1
+    )
+    assert p.monto_presupuesto == 500.0
+    assert p.mes_aplicacion == "2026-05"
+
+
+def test_presupuesto_create_sin_categoria():
+    p = PresupuestoCreate(
+        monto_presupuesto=300.0,
+        mes_aplicacion="2026-05",
+        id_usuario=1
+    )
+    assert p.id_categoria is None
+
+
+def test_presupuesto_create_sin_usuario_falla():
+    with pytest.raises(ValidationError):
+        PresupuestoCreate(
+            monto_presupuesto=500.0,
+            mes_aplicacion="2026-05"
+        )
+
+
+def test_presupuesto_update_todos_opcionales():
+    p = PresupuestoUpdate()
+    assert p.monto_presupuesto is None
+    assert p.id_categoria is None
+    assert p.mes_aplicacion is None
+    assert p.id_usuario is None
+
+
+def test_presupuesto_update_parcial():
+    p = PresupuestoUpdate(monto_presupuesto=999.0)
+    assert p.monto_presupuesto == 999.0
+    assert p.id_categoria is None
+
+
+def test_presupuesto_response_valido():
+    p = PresupuestoResponse(
+        id_presupuesto=1,
+        monto_presupuesto=500.0,
+        categoria="Comida",
+        mes_aplicacion="2026-05",
+        id_usuario=1
+    )
+    assert p.id_presupuesto == 1
+    assert p.categoria == "Comida"

--- a/tests/test_presupuestos/test_presupuesto_routes.py
+++ b/tests/test_presupuestos/test_presupuesto_routes.py
@@ -1,0 +1,53 @@
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+
+def test_crear_presupuesto_mes_actual():
+    from datetime import datetime
+    mes_actual = datetime.now().strftime("%Y-%m")
+    with patch("routes.presupuesto_routes.crear_presupuesto_mensual") as mock_crear:
+        mock_crear.return_value = {"mensaje": "Presupuesto creado correctamente"}
+        response = client.post("/presupuestos/", json={
+            "monto_presupuesto": 1000.0,
+            "id_categoria": 1,
+            "mes_aplicacion": mes_actual,
+            "id_usuario": 1
+        })
+        assert response.status_code == 200
+
+
+def test_crear_presupuesto_mes_incorrecto():
+    response = client.post("/presupuestos/", json={
+        "monto_presupuesto": 1000.0,
+        "id_categoria": 1,
+        "mes_aplicacion": "2020-01",
+        "id_usuario": 1
+    })
+    assert response.status_code == 400
+    assert "mes actual" in response.json()["detail"]
+
+
+def test_listar_presupuestos():
+    with patch("routes.presupuesto_routes.obtener_presupuestos") as mock_obtener:
+        mock_obtener.return_value = []
+        response = client.get("/presupuestos/")
+        assert response.status_code == 200
+
+
+def test_editar_presupuesto():
+    with patch("routes.presupuesto_routes.actualizar_presupuesto") as mock_actualizar:
+        mock_actualizar.return_value = {"mensaje": "Presupuesto actualizado"}
+        response = client.put("/presupuestos/1", json={
+            "monto_presupuesto": 2000.0
+        })
+        assert response.status_code == 200
+
+
+def test_eliminar_presupuesto():
+    with patch("routes.presupuesto_routes.eliminar_presupuesto") as mock_eliminar:
+        mock_eliminar.return_value = {"mensaje": "Presupuesto eliminado correctamente"}
+        response = client.delete("/presupuestos/1")
+        assert response.status_code == 200


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega pruebas unitarias para el módulo de presupuestos.

## Archivos
- tests/test_presupuestos/test_budget_service.py
- tests/test_presupuestos/test_budget_routes.py
- tests/test_presupuestos/test_presupuesto_routes.py
- tests/test_presupuestos/test_presupuesto_model.py

## Cobertura
- Crear presupuesto
- Actualizar presupuesto
- Eliminar presupuesto
- Validación de mes actual
- Validación de modelos Pydantic
- Manejo de errores